### PR TITLE
[BUGFIX] Added support for Fill Rule

### DIFF
--- a/src/main/kotlin/lt/neworld/vd2svg/converter/Converter.kt
+++ b/src/main/kotlin/lt/neworld/vd2svg/converter/Converter.kt
@@ -285,6 +285,15 @@ class Converter(val colors: ResourceCollector) {
         return parseColorHex(colorHex)
     }
 
+    private fun parseFillRule(currentRule: String): String {
+        return when (currentRule) {
+            "evenOdd" -> "evenodd"
+            "nonZero" -> "nonzero"
+            else ->
+                throw IllegalArgumentException("Unknown fill rule $currentRule")
+        }
+    }
+
     private fun parseColorHex(colorHex: String): Pair<String, Float?> {
         val color: String
         if (colorHex.length < 6) {
@@ -393,6 +402,7 @@ class Converter(val colors: ResourceCollector) {
 
     private fun Element.fixFill() {
         val fillColorName = attributes.get(ANDROID_NS, "fillColor")
+        val fillRuleAttr = attributes.getNamedItem("fill-rule")
         var fillColorHex: String? = null
         var fillAlpha: Float = attributes.get(ANDROID_NS, "fillAlpha")?.toFloatOrNull() ?: 1.0f
 
@@ -402,6 +412,10 @@ class Converter(val colors: ResourceCollector) {
                 fillAlpha *= androidAlpha
             }
             fillColorHex = colorHex
+        }
+
+        if (fillRuleAttr != null) {
+            setAttribute("fill-rule", parseFillRule(fillRuleAttr.nodeValue))
         }
 
         if (fillAlpha != 1.0f) {


### PR DESCRIPTION
Android vector supports `fill-rule` node, and this library does not convert the value of it to the SVG format. 
As I could see, inside of my Android  Studio, there are only two options - `evenOdd` and `nonZero`.

Added support to convert these to the SVG format.

Please test this within your environment. I loaded this in android studio, and tested it in my project. I cannot test your project as I don't know how to load it, and which IDE to use. Everything should work, as this is copy paste of the class from my project, but it's good to be safe. 